### PR TITLE
fixing pagination bug on infinite scroll

### DIFF
--- a/src/Fadion/Bouncy/ElasticCollection.php
+++ b/src/Fadion/Bouncy/ElasticCollection.php
@@ -29,9 +29,12 @@ class ElasticCollection extends Collection {
     public function paginate($perPage = 15)
     {
         $paginator = Paginator::make($this->items, count($this->items), $perPage);
-
-        $start = ($paginator->getCurrentPage() - 1) * $perPage;
-        $sliced = array_slice($this->items, $start, $perPage);
+        if (\Input::get(Paginator::getPageName(), 1) <= $paginator->getCurrentPage()) {
+            $start = ($paginator->getCurrentPage() - 1) * $perPage;
+            $sliced = array_slice($this->items, $start, $perPage);
+        } else {
+            $sliced = array();
+        }
 
         return Paginator::make($sliced, count($this->items), $perPage);
     }


### PR DESCRIPTION
pagination in Bouncy behaves in different way, what can cause troubles (e.g. when implementing infinite scroll)

using the Eloquent - when the requested page is out of range - no results are returned 

but in Bouncy implementation it returns the results from the last page - what is causing infinite scroll looping the last page forever (making it _realy_ infinite :)

this fix is making it behaving the same way as in Eloquent (when requesting page out of range - returns the empty array)
